### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Pylint
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/MapleClear/security/code-scanning/1](https://github.com/djleamen/MapleClear/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs Pylint, it only needs read access to the repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` and before the `on` key. This will apply the minimal permissions to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
