### PR TITLE
fix(server): disable CORS credentials with wildcard origins

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -184,7 +184,9 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # Allow all origins for local development
-    allow_credentials=True,
+    # Credentials must stay disabled while origins is a wildcard; otherwise
+    # any website can make credentialed requests against this local API.
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
The inference server configured CORS with `allow_origins=["*"]` **and** `allow_credentials=True`. In that combination Starlette reflects whatever `Origin` header the request carries and sets `Access-Control-Allow-Credentials: true`, which means any website a user visits can make credentialed cross-origin requests to the local MapleClear server.

This change sets `allow_credentials=False`. The server uses no cookies, sessions, or auth headers, so nothing depends on credentialed requests — the browser extension and demo are unaffected (wildcard origins are kept so extension origins still work).

## Verification
Tested header behavior with Starlette's `TestClient`:
- Before: `Access-Control-Allow-Origin: https://evil.example` + `Access-Control-Allow-Credentials: true` (origin reflected)
- After: `Access-Control-Allow-Origin: *`, no credentials header

https://claude.ai/code/session_016G2TQKFwzn3wYd5oTzmkRj

---
_Generated by [Claude Code](https://claude.ai/code/session_016G2TQKFwzn3wYd5oTzmkRj)_