### PR TITLE
fix(security): restrict CORS origins, route content-script API calls through background worker

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -89,13 +89,19 @@ class MapleClearBackground {
     try {
       const response = await fetch(`${API_BASE}${endpoint}`, {
         method: body === undefined ? 'GET' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
         body: body === undefined ? undefined : JSON.stringify(body),
         signal: AbortSignal.timeout(120000)
       });
 
       const data = await response.json().catch(() => undefined);
-      return { ok: response.ok, status: response.status, data };
+      if (!response.ok) {
+        // Surface FastAPI's error detail so callers can show it to the user.
+        const detail = data?.detail;
+        const error = typeof detail === 'string' ? detail : `HTTP ${response.status}`;
+        return { ok: false, status: response.status, data, error };
+      }
+      return { ok: true, status: response.status, data };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Request failed';
       return { ok: false, status: 0, error: message };

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -7,6 +7,15 @@
 
 import browser from 'webextension-polyfill';
 
+const API_BASE = 'http://127.0.0.1:11434';
+
+interface ApiResponse {
+  ok: boolean;
+  status: number;
+  data?: any;
+  error?: string;
+}
+
 class MapleClearBackground {
   constructor() {
     this.init();
@@ -17,7 +26,7 @@ class MapleClearBackground {
     browser.runtime.onMessage.addListener(this.handleMessage.bind(this));
     this.setupContextMenus();
     this.startStatusCheck();
-    console.log('🍁 MapleClear background script initialized');
+    console.log('\u{1F341} MapleClear background script initialized');
   }
 
   private async handleToolbarClick(tab: browser.Tabs.Tab): Promise<void> {
@@ -52,15 +61,44 @@ class MapleClearBackground {
     switch (message.type) {
       case 'GET_SERVER_STATUS':
         return this.getServerStatus();
-      
+
       case 'CHECK_PERMISSIONS':
         return this.checkPermissions();
-      
+
       case 'REQUEST_PERMISSION':
         return this.requestPermission(message.permission);
-      
+
+      case 'API_REQUEST':
+        return this.proxyApiRequest(message.endpoint, message.body);
+
       default:
         console.warn('Unknown message type:', message.type);
+    }
+  }
+
+  /**
+   * Proxy inference-server calls for content scripts. Requests made here
+   * carry the extension's origin, so the server can allowlist extension
+   * schemes instead of every page origin the content script runs on.
+   */
+  private async proxyApiRequest(endpoint: unknown, body: unknown): Promise<ApiResponse> {
+    if (typeof endpoint !== 'string' || !endpoint.startsWith('/')) {
+      return { ok: false, status: 0, error: 'Invalid API endpoint' };
+    }
+
+    try {
+      const response = await fetch(`${API_BASE}${endpoint}`, {
+        method: body === undefined ? 'GET' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: AbortSignal.timeout(120000)
+      });
+
+      const data = await response.json().catch(() => undefined);
+      return { ok: response.ok, status: response.status, data };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Request failed';
+      return { ok: false, status: 0, error: message };
     }
   }
 
@@ -123,7 +161,7 @@ class MapleClearBackground {
     info?: any;
   }> {
     try {
-      const response = await fetch('http://127.0.0.1:11434/health', {
+      const response = await fetch(`${API_BASE}/health`, {
         method: 'GET',
         signal: AbortSignal.timeout(5000)
       });

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -26,7 +26,7 @@ class MapleClearBackground {
     browser.runtime.onMessage.addListener(this.handleMessage.bind(this));
     this.setupContextMenus();
     this.startStatusCheck();
-    console.log('\u{1F341} MapleClear background script initialized');
+    console.log('🍁 MapleClear background script initialized');
   }
 
   private async handleToolbarClick(tab: browser.Tabs.Tab): Promise<void> {

--- a/extension/src/content-script.ts
+++ b/extension/src/content-script.ts
@@ -8,9 +8,15 @@
 declare const browser: any;
 
 interface Config {
-  API_BASE: string;
   PANEL_ID: string;
   TRIGGER_DOMAINS: string[];
+}
+
+interface ApiResponse {
+  ok: boolean;
+  status: number;
+  data?: any;
+  error?: string;
 }
 
 interface SelectionInfo {
@@ -20,7 +26,6 @@ interface SelectionInfo {
 }
 
 const CONFIG: Config = {
-  API_BASE: 'http://127.0.0.1:11434',
   PANEL_ID: 'mapleclear-panel',
   TRIGGER_DOMAINS: ['canada.ca', 'gc.ca']
 };
@@ -29,11 +34,25 @@ class MapleClearContentScript {
   private panel: HTMLElement | null = null;
   private currentSelection: SelectionInfo | null = null;
 
+  /**
+   * Call the inference server via the background worker so requests carry
+   * the extension's origin rather than the page's; the server only allows
+   * extension-scheme and localhost origins.
+   */
+  private async apiRequest(endpoint: string, body?: unknown): Promise<ApiResponse> {
+    try {
+      return await browser.runtime.sendMessage({ type: 'API_REQUEST', endpoint, body });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Request failed';
+      return { ok: false, status: 0, error: message };
+    }
+  }
+
   public async init(): Promise<void> {
-    console.log('🍁 MapleClear content script initializing...');
+    console.log('\u{1F341} MapleClear content script initializing...');
     
     if (!this.shouldActivate()) {
-      console.log('🚫 Not activating on this domain:', globalThis.location.hostname);
+      console.log('\u{1F6AB} Not activating on this domain:', globalThis.location.hostname);
       return;
     }
 
@@ -47,7 +66,7 @@ class MapleClearContentScript {
     
     this.setupAcronymDetection();
     
-    console.log('🍁 MapleClear content script initialized successfully');
+    console.log('\u{1F341} MapleClear content script initialized successfully');
   }
 
   private shouldActivate(): boolean {
@@ -68,7 +87,7 @@ class MapleClearContentScript {
   }
 
   private async handleMessage(message: any): Promise<any> {
-    console.log('📨 Content script received message:', message);
+    console.log('\u{1F4E8} Content script received message:', message);
     
     switch (message.type) {
       case 'TOGGLE_PANEL':
@@ -84,7 +103,7 @@ class MapleClearContentScript {
         return this.translateText(message.targetLanguage);
       
       case 'CREATE_SPLIT_SCREEN':
-        console.log('🔧 Creating split screen with:', message);
+        console.log('\u{1F527} Creating split screen with:', message);
         return this.createSplitScreen(message.action, message.language, message.languageName);
       
       case 'GET_PAGE_INFO':
@@ -259,7 +278,7 @@ class MapleClearContentScript {
       let body: any;
 
       if (action === 'simplify') {
-        endpoint = `${CONFIG.API_BASE}/simplify`;
+        endpoint = '/simplify';
         body = {
           text,
           target_grade: 7,
@@ -267,7 +286,7 @@ class MapleClearContentScript {
           context: globalThis.location.hostname
         };
       } else if (action === 'translate') {
-        endpoint = `${CONFIG.API_BASE}/translate`;
+        endpoint = '/translate';
         body = {
           text,
           target_language: options.targetLanguage || 'French',
@@ -278,19 +297,13 @@ class MapleClearContentScript {
         throw new Error(`Unknown action: ${action}`);
       }
 
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body)
-      });
+      const response = await this.apiRequest(endpoint, body);
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        throw new Error(`HTTP ${response.status}: ${response.error ?? 'request failed'}`);
       }
 
-      const data = await response.json();
+      const data = response.data;
       this.showResult(action, data);
       
       return { success: true, data };
@@ -466,14 +479,10 @@ class MapleClearContentScript {
     this.hideAcronymTooltip();
     
     try {
-      const response = await fetch(`${CONFIG.API_BASE}/expand-acronyms`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: acronym })
-      });
-      
+      const response = await this.apiRequest('/expand-acronyms', { text: acronym });
+
       if (response.ok) {
-        const data = await response.json();
+        const data = response.data;
         const expansion = data.acronyms?.[0];
         
         if (expansion) {
@@ -538,7 +547,7 @@ class MapleClearContentScript {
     return demoExpansions[acronym] || {
       acronym,
       expansion: 'Expansion not available',
-      definition: '🍁 MapleClear can provide definitions when connected to the server. Click the extension icon to get started!'
+      definition: '\u{1F341} MapleClear can provide definitions when connected to the server. Click the extension icon to get started!'
     };
   }
 
@@ -598,19 +607,12 @@ class MapleClearContentScript {
   }
 
   private async expandAcronym(acronym: string): Promise<void> {
-    try {
-      const response = await fetch(`${CONFIG.API_BASE}/expand-acronyms`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: acronym })
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        console.log('Acronym expansion:', data);
-      }
-    } catch (error) {
-      console.log('Could not expand acronym:', error);
+    const response = await this.apiRequest('/expand-acronyms', { text: acronym });
+
+    if (response.ok) {
+      console.log('Acronym expansion:', response.data);
+    } else {
+      console.log('Could not expand acronym:', response.error ?? response.status);
       alert('MapleClear server not available. Please start the server or click the MapleClear extension icon.');
     }
   }
@@ -633,11 +635,11 @@ class MapleClearContentScript {
 
   private async createSplitScreen(action: string, language: string, languageName: string): Promise<{ success: boolean; error?: string }> {
     try {
-      console.log('🔧 Creating split screen:', { action, language, languageName });
+      console.log('\u{1F527} Creating split screen:', { action, language, languageName });
       this.removeSplitScreen();
       
       const mainContent = this.extractMainContentForSplitScreen();
-      console.log('📄 Extracted main content length:', mainContent?.length || 0);
+      console.log('\u{1F4C4} Extracted main content length:', mainContent?.length || 0);
       
       if (!mainContent) {
         console.error('❌ No content found to process');
@@ -652,7 +654,7 @@ class MapleClearContentScript {
       originalPane.className = 'split-pane original-pane';
       originalPane.innerHTML = `
         <div class="pane-header">
-          <h3>📄 Original</h3>
+          <h3>\u{1F4C4} Original</h3>
           <button class="close-split" title="Close split view">×</button>
         </div>
         <div class="pane-content">
@@ -664,16 +666,16 @@ class MapleClearContentScript {
       processedPane.className = 'split-pane processed-pane';
       processedPane.innerHTML = `
         <div class="pane-header">
-          <h3>${action === 'simplify' ? '✨ Simplified' : `🌍 ${languageName}`}</h3>
+          <h3>${action === 'simplify' ? '✨ Simplified' : `\u{1F30D} ${languageName}`}</h3>
           <div class="pane-actions">
-            <button class="copy-content" title="Copy content">📋</button>
-            <button class="print-content" title="Print">🖨️</button>
+            <button class="copy-content" title="Copy content">\u{1F4CB}</button>
+            <button class="print-content" title="Print">\u{1F5A8}️</button>
           </div>
         </div>
         <div class="pane-content">
           <div class="processing-indicator">
             <div class="spinner"></div>
-            <h3>🍁 MapleClear is working...</h3>
+            <h3>\u{1F341} MapleClear is working...</h3>
             <p>${action === 'simplify' ? 'Simplifying your content into plain language' : `Translating to ${languageName}`}</p>
             <ul class="processing-steps">
               <li>Analyzing content structure</li>
@@ -762,7 +764,7 @@ class MapleClearContentScript {
           navigator.clipboard.writeText(processedContent.textContent || '').then(() => {
             copyButton.textContent = '✅';
             setTimeout(() => {
-              copyButton.textContent = '📋';
+              copyButton.textContent = '\u{1F4CB}';
             }, 2000);
           });
         }
@@ -777,7 +779,7 @@ class MapleClearContentScript {
           const printWindow = globalThis.open('', '_blank');
           if (printWindow) {
             printWindow.document.body.innerHTML = `
-              <h1>🍁 MapleClear - Processed Content</h1>
+              <h1>\u{1F341} MapleClear - Processed Content</h1>
               ${processedContent.innerHTML}
             `;
             printWindow.print();
@@ -790,7 +792,7 @@ class MapleClearContentScript {
   private async processContentForSplitScreen(action: string, language: string, content: string, processedPane: HTMLElement): Promise<void> {
     try {
       const textContent = this.extractTextFromHtml(content);
-      console.log('🔧 Processing content for split screen:', { action, language, contentLength: textContent.length });
+      console.log('\u{1F527} Processing content for split screen:', { action, language, contentLength: textContent.length });
 
       const result = await this.fetchProcessedContent(action, language, textContent);
       const processedText = this.extractProcessedText(result);
@@ -814,21 +816,16 @@ class MapleClearContentScript {
       ? { text: textContent, target_grade: 7, preserve_acronyms: true }
       : { text: textContent, target_language: language, preserve_terms: true };
 
-    console.log('🚀 Making API request to:', `${CONFIG.API_BASE}${endpoint}`);
+    console.log('\u{1F680} Making API request to:', endpoint);
 
-    const response = await fetch(`${CONFIG.API_BASE}${endpoint}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(requestData)
-    });
+    const response = await this.apiRequest(endpoint, requestData);
 
     if (!response.ok) {
       throw new Error(`Server responded with status ${response.status}`);
     }
 
-    const result = await response.json();
-    console.log('📦 API response received:', result);
-    return result;
+    console.log('\u{1F4E6} API response received:', response.data);
+    return response.data;
   }
 
   private extractProcessedText(result: any): string {
@@ -864,7 +861,7 @@ class MapleClearContentScript {
       return;
     }
 
-    console.log('🎨 Formatting content for display...');
+    console.log('\u{1F3A8} Formatting content for display...');
     const finalContent = this.formatContentForDisplay(processedText);
     
     this.updatePaneContent(paneContent as HTMLElement, finalContent);
@@ -991,13 +988,13 @@ class MapleClearContentScript {
   }
 
   private updatePaneContent(paneContent: HTMLElement, finalContent: string): void {
-    console.log('📝 Final formatted content length:', finalContent.length);
+    console.log('\u{1F4DD} Final formatted content length:', finalContent.length);
     
     paneContent.innerHTML = '';
     paneContent.innerHTML = finalContent;
     
     this.applyContentStyling(paneContent);
-    console.log('🎨 Content set, pane content innerHTML length:', paneContent.innerHTML.length);
+    console.log('\u{1F3A8} Content set, pane content innerHTML length:', paneContent.innerHTML.length);
   }
 
   private applyContentStyling(paneContent: HTMLElement): void {
@@ -1027,7 +1024,7 @@ class MapleClearContentScript {
       element.style.visibility = 'visible';
       element.style.opacity = '1';
     });
-    console.log('🎨 Applied content styling to', allElements.length, 'child elements');
+    console.log('\u{1F3A8} Applied content styling to', allElements.length, 'child elements');
   }
 
   private handleProcessingError(error: unknown, processedPane: HTMLElement): void {

--- a/extension/src/content-script.ts
+++ b/extension/src/content-script.ts
@@ -49,10 +49,10 @@ class MapleClearContentScript {
   }
 
   public async init(): Promise<void> {
-    console.log('\u{1F341} MapleClear content script initializing...');
+    console.log('🍁 MapleClear content script initializing...');
     
     if (!this.shouldActivate()) {
-      console.log('\u{1F6AB} Not activating on this domain:', globalThis.location.hostname);
+      console.log('🚫 Not activating on this domain:', globalThis.location.hostname);
       return;
     }
 
@@ -66,7 +66,7 @@ class MapleClearContentScript {
     
     this.setupAcronymDetection();
     
-    console.log('\u{1F341} MapleClear content script initialized successfully');
+    console.log('🍁 MapleClear content script initialized successfully');
   }
 
   private shouldActivate(): boolean {
@@ -87,7 +87,7 @@ class MapleClearContentScript {
   }
 
   private async handleMessage(message: any): Promise<any> {
-    console.log('\u{1F4E8} Content script received message:', message);
+    console.log('📨 Content script received message:', message);
     
     switch (message.type) {
       case 'TOGGLE_PANEL':
@@ -103,7 +103,7 @@ class MapleClearContentScript {
         return this.translateText(message.targetLanguage);
       
       case 'CREATE_SPLIT_SCREEN':
-        console.log('\u{1F527} Creating split screen with:', message);
+        console.log('🔧 Creating split screen with:', message);
         return this.createSplitScreen(message.action, message.language, message.languageName);
       
       case 'GET_PAGE_INFO':
@@ -547,7 +547,7 @@ class MapleClearContentScript {
     return demoExpansions[acronym] || {
       acronym,
       expansion: 'Expansion not available',
-      definition: '\u{1F341} MapleClear can provide definitions when connected to the server. Click the extension icon to get started!'
+      definition: '🍁 MapleClear can provide definitions when connected to the server. Click the extension icon to get started!'
     };
   }
 
@@ -635,11 +635,11 @@ class MapleClearContentScript {
 
   private async createSplitScreen(action: string, language: string, languageName: string): Promise<{ success: boolean; error?: string }> {
     try {
-      console.log('\u{1F527} Creating split screen:', { action, language, languageName });
+      console.log('🔧 Creating split screen:', { action, language, languageName });
       this.removeSplitScreen();
       
       const mainContent = this.extractMainContentForSplitScreen();
-      console.log('\u{1F4C4} Extracted main content length:', mainContent?.length || 0);
+      console.log('📄 Extracted main content length:', mainContent?.length || 0);
       
       if (!mainContent) {
         console.error('❌ No content found to process');
@@ -654,7 +654,7 @@ class MapleClearContentScript {
       originalPane.className = 'split-pane original-pane';
       originalPane.innerHTML = `
         <div class="pane-header">
-          <h3>\u{1F4C4} Original</h3>
+          <h3>📄 Original</h3>
           <button class="close-split" title="Close split view">×</button>
         </div>
         <div class="pane-content">
@@ -666,16 +666,16 @@ class MapleClearContentScript {
       processedPane.className = 'split-pane processed-pane';
       processedPane.innerHTML = `
         <div class="pane-header">
-          <h3>${action === 'simplify' ? '✨ Simplified' : `\u{1F30D} ${languageName}`}</h3>
+          <h3>${action === 'simplify' ? '✨ Simplified' : `🌍 ${languageName}`}</h3>
           <div class="pane-actions">
-            <button class="copy-content" title="Copy content">\u{1F4CB}</button>
-            <button class="print-content" title="Print">\u{1F5A8}️</button>
+            <button class="copy-content" title="Copy content">📋</button>
+            <button class="print-content" title="Print">🖨️</button>
           </div>
         </div>
         <div class="pane-content">
           <div class="processing-indicator">
             <div class="spinner"></div>
-            <h3>\u{1F341} MapleClear is working...</h3>
+            <h3>🍁 MapleClear is working...</h3>
             <p>${action === 'simplify' ? 'Simplifying your content into plain language' : `Translating to ${languageName}`}</p>
             <ul class="processing-steps">
               <li>Analyzing content structure</li>
@@ -764,7 +764,7 @@ class MapleClearContentScript {
           navigator.clipboard.writeText(processedContent.textContent || '').then(() => {
             copyButton.textContent = '✅';
             setTimeout(() => {
-              copyButton.textContent = '\u{1F4CB}';
+              copyButton.textContent = '📋';
             }, 2000);
           });
         }
@@ -779,7 +779,7 @@ class MapleClearContentScript {
           const printWindow = globalThis.open('', '_blank');
           if (printWindow) {
             printWindow.document.body.innerHTML = `
-              <h1>\u{1F341} MapleClear - Processed Content</h1>
+              <h1>🍁 MapleClear - Processed Content</h1>
               ${processedContent.innerHTML}
             `;
             printWindow.print();
@@ -792,7 +792,7 @@ class MapleClearContentScript {
   private async processContentForSplitScreen(action: string, language: string, content: string, processedPane: HTMLElement): Promise<void> {
     try {
       const textContent = this.extractTextFromHtml(content);
-      console.log('\u{1F527} Processing content for split screen:', { action, language, contentLength: textContent.length });
+      console.log('🔧 Processing content for split screen:', { action, language, contentLength: textContent.length });
 
       const result = await this.fetchProcessedContent(action, language, textContent);
       const processedText = this.extractProcessedText(result);
@@ -816,7 +816,7 @@ class MapleClearContentScript {
       ? { text: textContent, target_grade: 7, preserve_acronyms: true }
       : { text: textContent, target_language: language, preserve_terms: true };
 
-    console.log('\u{1F680} Making API request to:', endpoint);
+    console.log('🚀 Making API request to:', endpoint);
 
     const response = await this.apiRequest(endpoint, requestData);
 
@@ -824,7 +824,7 @@ class MapleClearContentScript {
       throw new Error(`Server responded with status ${response.status}`);
     }
 
-    console.log('\u{1F4E6} API response received:', response.data);
+    console.log('📦 API response received:', response.data);
     return response.data;
   }
 
@@ -861,7 +861,7 @@ class MapleClearContentScript {
       return;
     }
 
-    console.log('\u{1F3A8} Formatting content for display...');
+    console.log('🎨 Formatting content for display...');
     const finalContent = this.formatContentForDisplay(processedText);
     
     this.updatePaneContent(paneContent as HTMLElement, finalContent);
@@ -988,13 +988,13 @@ class MapleClearContentScript {
   }
 
   private updatePaneContent(paneContent: HTMLElement, finalContent: string): void {
-    console.log('\u{1F4DD} Final formatted content length:', finalContent.length);
+    console.log('📝 Final formatted content length:', finalContent.length);
     
     paneContent.innerHTML = '';
     paneContent.innerHTML = finalContent;
     
     this.applyContentStyling(paneContent);
-    console.log('\u{1F3A8} Content set, pane content innerHTML length:', paneContent.innerHTML.length);
+    console.log('🎨 Content set, pane content innerHTML length:', paneContent.innerHTML.length);
   }
 
   private applyContentStyling(paneContent: HTMLElement): void {
@@ -1024,7 +1024,7 @@ class MapleClearContentScript {
       element.style.visibility = 'visible';
       element.style.opacity = '1';
     });
-    console.log('\u{1F3A8} Applied content styling to', allElements.length, 'child elements');
+    console.log('🎨 Applied content styling to', allElements.length, 'child elements');
   }
 
   private handleProcessingError(error: unknown, processedPane: HTMLElement): void {

--- a/server/app.py
+++ b/server/app.py
@@ -123,7 +123,7 @@ class HealthResponse(BaseModel):
 @asynccontextmanager
 async def lifespan(fastapi_app: FastAPI):
     """Manage startup and shutdown events for the FastAPI app."""
-    print("\U0001F341 Starting MapleClear server...")
+    print("🍁 Starting MapleClear server...")
     print(f"Backend: {Config.BACKEND}")
     print(f"Model path: {Config.MODEL_PATH}")
     print(f"Adapters: {Config.ADAPTERS}")

--- a/server/app.py
+++ b/server/app.py
@@ -123,7 +123,7 @@ class HealthResponse(BaseModel):
 @asynccontextmanager
 async def lifespan(fastapi_app: FastAPI):
     """Manage startup and shutdown events for the FastAPI app."""
-    print("🍁 Starting MapleClear server...")
+    print("\U0001F341 Starting MapleClear server...")
     print(f"Backend: {Config.BACKEND}")
     print(f"Model path: {Config.MODEL_PATH}")
     print(f"Adapters: {Config.ADAPTERS}")
@@ -181,11 +181,18 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# Cross-origin access is limited to browser-extension origins (the extension
+# routes all server calls through its background worker) plus localhost pages
+# for dev/demo. Override with MAPLECLEAR_ALLOWED_ORIGIN_REGEX if needed.
+ALLOWED_ORIGIN_REGEX = os.getenv(
+    "MAPLECLEAR_ALLOWED_ORIGIN_REGEX",
+    r"^(chrome-extension|moz-extension|safari-web-extension)://[a-z0-9-]+$"
+    r"|^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Allow all origins for local development
-    # Credentials must stay disabled while origins is a wildcard; otherwise
-    # any website can make credentialed requests against this local API.
+    allow_origin_regex=ALLOWED_ORIGIN_REGEX,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Implements the fix proposed in #24 (manual implementation — Copilot's sessions on the issue failed to start three times).

## Problem
`allow_origins=["*"]` remained on the inference server, so any website could make cross-origin requests to `127.0.0.1:11434` and read responses — including driving paid backends like Groq via the user's environment key. The wildcard couldn't simply be tightened because content scripts fetched the server directly from page context, where requests carry the *page's* origin (`canada.ca`, `gc.ca`, `localhost`, or `null` for `file://`).

## Changes
- **Extension** — content scripts no longer call the server directly. All four call sites (`/simplify`, `/translate`, `/expand-acronyms` ×2) now send an `API_REQUEST` message to the background service worker, which performs the fetch with the extension's own origin. The worker validates the endpoint shape and returns `{ok, status, data, error}`.
- **Server** — `allow_origins=["*"]` is replaced with `allow_origin_regex`, env-configurable via `MAPLECLEAR_ALLOWED_ORIGIN_REGEX`, defaulting to `chrome-extension://` / `moz-extension://` / `safari-web-extension://` origins plus `http(s)://localhost` and `127.0.0.1` (any port) for dev/demo pages.
- **`file:///*` flow (issue item 3)** — kept, and now safe: those pages' calls go through the worker, so the server never needs to allow `null` origins. Popup/panel extension pages keep their direct fetches (they already run on the extension origin).

## Verification
- `tsc --noEmit` passes (note: ran with `ignoreDeprecations: "5.0"` locally — the committed tsconfig value `"6.0"` is rejected by the pinned TypeScript `^5.2.2`, a pre-existing mismatch worth a separate look)
- CORS policy tested with FastAPI `TestClient`: extension origins (Chrome ID, Firefox UUID, Safari), `localhost:3000`, `localhost`, and `127.0.0.1:5500` are allowed; `https://evil.com`, `null`, `http://127.0.0.1.evil.com`, `https://localhost.evil.com`, and subdomain tricks are denied; preflight from an extension origin succeeds
- `python -m py_compile server/app.py` passes

Closes #24

https://claude.ai/code/session_01DFwCn17gekNRatF9DuN26J

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFwCn17gekNRatF9DuN26J)_