### PR TITLE
fix(extension): add request timeouts to panel.js server fetches

### DIFF
--- a/extension/src/panel.js
+++ b/extension/src/panel.js
@@ -2,7 +2,9 @@
  * Panel functionality for MapleClear extension
  */
 
-// Request timeouts (ms) for the local inference server, matching background.ts.
+// Local inference server config, matching background.ts.
+const API_BASE = 'http://127.0.0.1:11434';
+// Request timeouts (ms) for the local inference server.
 const INFERENCE_TIMEOUT_MS = 120000;
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
 
@@ -87,7 +89,7 @@ class MapleClearPanel {
 
   async checkServerStatus() {
     try {
-      const response = await fetch('http://127.0.0.1:11434/health', {
+      const response = await fetch(`${API_BASE}/health`, {
         signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS)
       });
       if (!response.ok) {
@@ -229,7 +231,7 @@ class MapleClearPanel {
       preserve_terms: true
     };
 
-    const response = await fetch(`http://127.0.0.1:11434${endpoint}`, {
+    const response = await fetch(`${API_BASE}${endpoint}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/extension/src/panel.js
+++ b/extension/src/panel.js
@@ -2,6 +2,10 @@
  * Panel functionality for MapleClear extension
  */
 
+// Request timeouts (ms) for the local inference server, matching background.ts.
+const INFERENCE_TIMEOUT_MS = 120000;
+const HEALTH_CHECK_TIMEOUT_MS = 5000;
+
 class MapleClearPanel {
   constructor() {
     this.originalContent = '';
@@ -84,10 +88,13 @@ class MapleClearPanel {
   async checkServerStatus() {
     try {
       const response = await fetch('http://127.0.0.1:11434/health', {
-        signal: AbortSignal.timeout(5000)
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS)
       });
+      if (!response.ok) {
+        throw new Error(`Health check failed with status ${response.status}`);
+      }
       const data = await response.json();
-      
+
       this.updateServerStatus(true, data);
     } catch (error) {
       console.error('Server status check failed:', error);
@@ -228,7 +235,7 @@ class MapleClearPanel {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(requestData),
-      signal: AbortSignal.timeout(120000)
+      signal: AbortSignal.timeout(INFERENCE_TIMEOUT_MS)
     });
 
     if (!response.ok) {

--- a/extension/src/panel.js
+++ b/extension/src/panel.js
@@ -83,7 +83,9 @@ class MapleClearPanel {
 
   async checkServerStatus() {
     try {
-      const response = await fetch('http://127.0.0.1:11434/health');
+      const response = await fetch('http://127.0.0.1:11434/health', {
+        signal: AbortSignal.timeout(5000)
+      });
       const data = await response.json();
       
       this.updateServerStatus(true, data);
@@ -225,7 +227,8 @@ class MapleClearPanel {
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(requestData)
+      body: JSON.stringify(requestData),
+      signal: AbortSignal.timeout(120000)
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## What & why

`extension/src/panel.js` calls the local inference server directly via `fetch()` with **no timeout** in two places:

- `callServer` — `POST http://127.0.0.1:11434{endpoint}` for simplify/translate inference
- `checkServerStatus` — `GET http://127.0.0.1:11434/health`

If the local server hangs or stalls (rather than refusing the connection), these calls never settle, leaving the side panel stuck on the "Processing…" spinner indefinitely with no recovery.

This is inconsistent with `extension/src/background.ts`, which deliberately guards every fetch with `AbortSignal.timeout(...)` — `120000` for inference and `5000` for the health check.

## Change

Add `signal: AbortSignal.timeout(...)` to both `panel.js` fetches, reusing the exact values from `background.ts`:

- inference `POST` → `AbortSignal.timeout(120000)`
- `/health` `GET` → `AbortSignal.timeout(5000)`

Both call sites already sit inside `try/catch` blocks (`callServer` propagates to the action handler's catch → `showError`; `checkServerStatus` has its own catch → disconnected state), so a timeout abort simply triggers the existing failure UI instead of hanging.

## Testing

- `node --check extension/src/panel.js` passes.
- `AbortSignal.timeout` is standard in the Chromium extension runtime and is already used by `background.ts` in this repo.
- `panel.js` is copied verbatim by the build (`build:deps`) and is not covered by the TS-only `lint`/`typecheck` scripts, so no build-config change is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0154vS9xGVYkJfLuAQ37gysQ)_