### PR TITLE
fix(extension): guard null readability grades and privileged-page URLs

### DIFF
--- a/extension/src/content-script.ts
+++ b/extension/src/content-script.ts
@@ -337,6 +337,12 @@ class MapleClearContentScript {
     if (!content) return;
 
     if (action === 'simplify') {
+      const readingGrade = data.readability_grade != null
+        ? data.readability_grade.toFixed(1)
+        : 'N/A';
+      const originalGradeSuffix = data.original_grade != null
+        ? ` (was ${data.original_grade.toFixed(1)})`
+        : '';
       content.innerHTML = `
         <div class="result">
           <h3>Simplified Text</h3>
@@ -348,7 +354,7 @@ class MapleClearContentScript {
           </ul>
 
           <div class="reading-grade">
-            Reading level: Grade ${data.readability_grade != null ? data.readability_grade.toFixed(1) : 'N/A'}${data.original_grade != null ? ` (was ${data.original_grade.toFixed(1)})` : ''}
+            Reading level: Grade ${readingGrade}${originalGradeSuffix}
           </div>
 
           ${data.cautions.length > 0 ? `

--- a/extension/src/content-script.ts
+++ b/extension/src/content-script.ts
@@ -348,8 +348,7 @@ class MapleClearContentScript {
           </ul>
 
           <div class="reading-grade">
-            Reading level: Grade ${data.readability_grade.toFixed(1)}
-            (was ${data.original_grade.toFixed(1)})
+            Reading level: Grade ${data.readability_grade != null ? data.readability_grade.toFixed(1) : 'N/A'}${data.original_grade != null ? ` (was ${data.original_grade.toFixed(1)})` : ''}
           </div>
 
           ${data.cautions.length > 0 ? `

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -101,7 +101,12 @@ class MapleClearPopup {
         domainElement.textContent = domain;
       }
     }).catch(() => {
-      // Ignore transient tab-query/URL errors; the domain display is optional.
+      // Privileged pages (chrome://, the New Tab page) reject the tab query or
+      // URL parse; clear the domain display rather than leaving a stale value.
+      const domainElement = document.getElementById('current-domain');
+      if (domainElement) {
+        domainElement.textContent = '';
+      }
     });
   }
 

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -88,12 +88,20 @@ class MapleClearPopup {
   updatePageInfo() {
     browser.tabs.query({ active: true, currentWindow: true }).then(tabs => {
       const tab = tabs[0];
+      // tab.url is undefined on privileged pages (chrome://, the New Tab
+      // page) or without the "tabs" permission; new URL(undefined) would
+      // throw and reject the promise, so guard before parsing.
+      if (!tab || !tab.url) {
+        return;
+      }
       const domain = new URL(tab.url).hostname;
-      
+
       const domainElement = document.getElementById('current-domain');
       if (domainElement) {
         domainElement.textContent = domain;
       }
+    }).catch(() => {
+      // Ignore transient tab-query/URL errors; the domain display is optional.
     });
   }
 


### PR DESCRIPTION
## Summary

Two runtime crashes in the popup / simplify flow.

### 1. `content-script.ts` — `null.toFixed()` crash on every simplify result
`showResult()` called `data.readability_grade.toFixed(1)` and `data.original_grade.toFixed(1)`, but in `server/prompts/schema.py` both are `Optional[float] = None`, and the default Groq backend never populates `original_grade`. So `data.original_grade` is `null` at runtime and `null.toFixed(1)` threw — the throw is caught by `processText`, so the user saw an **error message instead of their simplified text**. Now renders `N/A` when `readability_grade` is missing and drops the `(was …)` clause entirely when `original_grade` is missing.

### 2. `popup.js` — unhandled rejection on privileged pages
`updatePageInfo()` ran `new URL(tab.url).hostname` inside a `.then()` with no guard or `.catch()`. On `chrome://` pages, the New Tab page, or without the `tabs` permission, `tab.url` is `undefined` and `new URL(undefined)` threw, producing an unhandled promise rejection. Now guards the missing URL and adds a `.catch()`.

## Testing
- `npm run typecheck` (tsc --noEmit) → clean
- `npm run lint` (eslint, `--max-warnings 0`) → clean
- `npm test` (vitest) → passes
- `node --check extension/src/popup.js` → OK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfqQPWkTooa6Hp62mnU518)_